### PR TITLE
upgrade to version 1.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 LABEL maintainer "Dave Larson <delarson@wustl.edu>"
 
 # Build dependencies
-RUN MANTA_VERSION=1.5.0 \
+RUN MANTA_VERSION=1.6.0 \
     && buildDeps=' \
         gcc \
         g++ \

--- a/manta_helper.py
+++ b/manta_helper.py
@@ -1,6 +1,6 @@
 import sys, subprocess
 
-config_command = ['/usr/bin/python', '/usr/local/bin/configManta.py']
+config_command = ['/usr/bin/python', '/usr/bin/manta/bin/configManta.py']
 config_command.extend(sys.argv[1:])
 subprocess.check_call(config_command)
 


### PR DESCRIPTION
this will allow a docker image containing manta version 1.6.0 to be created